### PR TITLE
Add OpenCV 4.11 compatibility for ArUco/ChArUco pipeline (backward compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Running on macbook air M2 using MPS
 - Full pipeline: `>= 30 fps`
 
 ## Setup for training (and inference on val data)
-`requirements.txt` should contain a valid list of requirements, notice `opencv-contrib` is `<4.7`.  
+`requirements.txt` should contain a valid list of requirements.  
+Current compatibility target is `opencv-contrib-python>=4.6,<4.12` (including OpenCV 4.11).  
+OpenCV ArUco API differences are handled at runtime in `src/aruco_utils.py` by checking available symbols (`hasattr`) and selecting the compatible code path (e.g. `ArucoDetector` vs `detectMarkers`, `CharucoBoard` vs `CharucoBoard_create`).
 If you wan to run `inference.py` or the `data.py` and `data_refinenet.py` you will need to install [gridwindow](https://github.com/JunkyByte/python-gridwindow) which is used for visualization (or replace everything with normal `cv2` windows)
 Synthetic data for `DeepCharuco` training
 ![data](https://i.imgur.com/KasncjL.png)  

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ albumentations==1.3.0
 imgaug==0.4.0
 numba==0.56.4
 numpydoc==1.5.0
-opencv_python<4.7.0
+opencv-contrib-python>=4.6,<4.12
 pytorch_lightning==1.9.3
 scipy==1.10.1
 torchinfo==1.7.2

--- a/src/benchmark.py
+++ b/src/benchmark.py
@@ -17,13 +17,13 @@ if __name__ == '__main__':
     elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
         device = 'mps'
 
-    from aruco_utils import get_aruco_dict, get_board
+    from aruco_utils import get_aruco_dict, get_board, create_detector_parameters
     config = load_configuration(configs.CONFIG_PATH)
 
     # Load aruco board for cv2 inference
     dictionary = get_aruco_dict(config.board_name)
     board = get_board(config)
-    parameters = cv2.aruco.DetectorParameters_create()
+    parameters = create_detector_parameters()
 
     # Load models
     deepc_path = "./reference/longrun-epoch=99-step=369700.ckpt"

--- a/src/inference.py
+++ b/src/inference.py
@@ -89,13 +89,13 @@ if __name__ == '__main__':
     from gridwindow import MagicGrid
     from utils import pixel_error
     from data import CharucoDataset
-    from aruco_utils import get_aruco_dict, get_board
+    from aruco_utils import get_aruco_dict, get_board, create_detector_parameters
     config = load_configuration(configs.CONFIG_PATH)
 
     # Load aruco board for cv2 inference
     dictionary = get_aruco_dict(config.board_name)
     board = get_board(config)
-    parameters = cv2.aruco.DetectorParameters_create()
+    parameters = create_detector_parameters()
 
     # Load models
     deepc_path = "./reference/longrun-epoch=99-step=369700.ckpt"

--- a/src/pose_estimation.py
+++ b/src/pose_estimation.py
@@ -9,7 +9,15 @@ import tqdm
 from configs import load_configuration
 from utils import save_video
 from inference import infer_image, load_models, solve_pnp
-from aruco_utils import draw_inner_corners, board_image, get_board, cv2_aruco_detect, get_aruco_dict
+from aruco_utils import (
+    draw_inner_corners,
+    board_image,
+    get_board,
+    cv2_aruco_detect,
+    get_aruco_dict,
+    create_detector_parameters,
+    get_board_object_points,
+)
 from gridwindow import MagicGrid
 
 
@@ -36,7 +44,7 @@ if __name__ == '__main__':
 
     # These are needed just for comparison with cv2
     dictionary = get_aruco_dict(config.board_name)
-    parameters = cv2.aruco.DetectorParameters_create()
+    parameters = create_detector_parameters()
 
     frames = []
     if "DISPLAY" in os.environ:
@@ -64,7 +72,7 @@ if __name__ == '__main__':
                                                           dist_coeffs, None,
                                                           None)
 
-        object_points_found = np.array(board.objPoints)[ids].reshape((-1, 3))
+        object_points_found = get_board_object_points(board)[ids].reshape((-1, 3))
         image_points = np.array(corners).reshape((-1, 2))
 
         ret_cv2 = False


### PR DESCRIPTION
## Background

OpenCV 4.11 introduces ArUco/ChArUco API differences in the Python bindings that may introduce incompatibilities with older code paths.

This PR adds a runtime compatibility layer so the pipeline works across multiple OpenCV versions without breaking existing behavior.

---

## Changes

- `src/aruco_utils.py`
  - Added runtime symbol-based dispatch using `hasattr` for API compatibility
  - Compatibility handling for:
    - `DetectorParameters` / `DetectorParameters_create`
    - `ArucoDetector` / `detectMarkers`
    - `CharucoBoard(...)` / `CharucoBoard_create(...)`
    - `getPredefinedDictionary` / `Dictionary_get`
    - `getObjPoints()` / `objPoints`
    - `generateImage` / `draw`

- `src/inference.py`, `src/benchmark.py`, `src/pose_estimation.py`
  - Updated call sites to use compatibility wrappers where required

- `requirements.txt`
  - Updated OpenCV constraint to: `opencv-contrib-python>=4.6,<4.12`

- `README.md`
  - Removed outdated fixed version constraint (`opencv-contrib < 4.7`)
  - Documented supported OpenCV range and runtime fallback strategy

---

## Compatibility Strategy

This implementation does not rely on version-string checks.  
Instead, it detects available OpenCV symbols at runtime and selects the appropriate execution path.

This keeps the behavior stable across OpenCV 4.6–4.11 while preserving backward compatibility.

---

## Validation

- Smoke-tested inference and training paths on OpenCV 4.11
- Verified benchmark script executes successfully and reports FPS
- Confirmed fallback logic works for both legacy and newer API paths
